### PR TITLE
Add alias mapping for CSV headers

### DIFF
--- a/src/balance_pipeline/csv_consolidator.py
+++ b/src/balance_pipeline/csv_consolidator.py
@@ -16,6 +16,7 @@
 # -----------------------------------------------------------------------------
 # Change Log
 # Date        Author            Type        Note
+# 2025-05-28  Cline (AI)        feat        Map common header aliases in _normalize_csv_header.
 # 2025-05-16  Cline (AI)        feat        Initial creation of the module.
 ###############################################################################
 
@@ -93,7 +94,7 @@ def coerce_bool(series: pd.Series) -> pd.Series:
 
 
 def _normalize_csv_header(header: str) -> str:
-    """Normalizes a CSV column header: lowercase, strip, remove special chars except space."""
+    """Normalize a CSV column header."""
     if not isinstance(header, str):
         return ""
     # Convert to lowercase
@@ -102,7 +103,15 @@ def _normalize_csv_header(header: str) -> str:
     normalized = re.sub(r'[^a-z0-9\s]', '', normalized).strip()
     # Replace multiple spaces with a single space
     normalized = re.sub(r'\s+', ' ', normalized)
-    return normalized
+
+    alias_map = {
+        'txn date': 'date',
+        'transaction date': 'date',
+        'account name': 'account',
+        'running balance': 'balance',
+    }
+
+    return alias_map.get(normalized, normalized)
 
 def find_matching_schema(
     df_headers: List[str],

--- a/tests/test_csv_consolidator.py
+++ b/tests/test_csv_consolidator.py
@@ -17,7 +17,11 @@ import pandas as pd
 from pathlib import Path
 
 # Module to test
-from balance_pipeline.csv_consolidator import process_csv_files, MANDATORY_MASTER_COLS
+from balance_pipeline.csv_consolidator import (
+    process_csv_files,
+    MANDATORY_MASTER_COLS,
+    _normalize_csv_header,
+)
 
 # --- Constants for Test Fixtures ---
 # Assuming CWD for tests will be the project root BALANCE-pyexcel/
@@ -110,3 +114,15 @@ def test_process_single_csv_file(csv_filename: str, params: dict):
 # - Test with a schema that has `derived_columns` (once an example exists in schema_registry.yml).
 # - Test specific transformations like date parsing with explicit formats, amount_regex.
 # - Test the complex sign rule once implemented.
+
+
+def test_normalize_csv_header_aliases():
+    """Common header aliases should map to canonical names."""
+    cases = {
+        'Txn Date': 'date',
+        'Account Name': 'account',
+        'running balance': 'balance',
+    }
+
+    for raw, expected in cases.items():
+        assert _normalize_csv_header(raw) == expected


### PR DESCRIPTION
## Summary
- update `_normalize_csv_header` to translate common header aliases
- note change in csv_consolidator change log
- test the alias mapping logic

## Testing
- `poetry run ruff check .`
- `poetry run mypy src/ --strict` *(fails: missing stubs)*
- `poetry run pytest -q` *(fails: 12 failed, 70 passed)*
- `poetry run snakeviz --version` *(fails: command not found)*