### PR TITLE
Add generic bank schema test

### DIFF
--- a/rules/schema_registry.yml
+++ b/rules/schema_registry.yml
@@ -226,3 +226,16 @@
   sign_rule: as_is
   extra_static_cols:
     Source: TestSource2
+- id: generic_bank
+  match_filename: generic_bank_*.csv
+  header_signature:
+    - Date
+    - Description
+    - Amount
+  column_map:
+    Date: Date
+    Description: OriginalDescription
+    Amount: Amount
+  sign_rule: as_is
+  extra_static_cols:
+    Source: GenericBank

--- a/tests/test_csv_consolidator.py
+++ b/tests/test_csv_consolidator.py
@@ -110,3 +110,15 @@ def test_process_single_csv_file(csv_filename: str, params: dict):
 # - Test with a schema that has `derived_columns` (once an example exists in schema_registry.yml).
 # - Test specific transformations like date parsing with explicit formats, amount_regex.
 # - Test the complex sign rule once implemented.
+
+
+def test_generic_bank_schema(tmp_path: Path) -> None:
+    """Ensure a simple CSV matches the generic_bank schema."""
+
+    csv_file = tmp_path / "generic_bank_01.csv"
+    csv_file.write_text(
+        "Date,Description,Amount\n2025-05-01,Coffee,-2.50\n", encoding="utf-8"
+    )
+    df = process_csv_files([csv_file])
+    assert not df.empty
+    assert df["DataSourceName"].iloc[0] == "generic_bank"

--- a/top.py
+++ b/top.py
@@ -1,7 +1,0 @@
-import pathlib, sys 
-file_path = 'src\\balance_pipeline\\ingest.py' 
-max_lines = 200 
-with open(file_path, encoding='utf-8') as f: 
-    for i,line in enumerate(f,1): 
-    if i > max_lines: break 
-    print(f\"{i:4}: {line.rstrip()}\") 


### PR DESCRIPTION
## Summary
- add `generic_bank` schema entry
- verify schema detection with a new regression test
- remove obsolete `top.py`

## Testing
- `poetry run ruff check .`
- `poetry run ruff format .`
- `poetry run mypy src/ --strict` *(fails: missing stubs)*
- `poetry run pytest -q` *(fails: 16 failed tests)*
- `poetry run snakeviz --version` *(fails: command not found)*